### PR TITLE
sandbox: add ctrl+enter support to trigger render()

### DIFF
--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -50,6 +50,13 @@
     iframe {
       border: none;
     }
+    .hint {
+      color: gray;
+      border-right: 1px solid #ccc;
+      padding-right: 10px;
+      margin-right: 5px;
+      box-shadow: 1px 0 white;
+    }
   </style>
 </head>
 
@@ -57,6 +64,7 @@
 <div id=editor>
   <div id=controls>
     <button onclick="render()">Render</button>
+    <span class=hint>or press cmd/ctrl + enter</span>
     <span id=docname></span>
   </div>
   <div id=save-load>

--- a/sandbox/sandbox.js
+++ b/sandbox/sandbox.js
@@ -141,7 +141,7 @@ function loadFile() {
 window.addEventListener("hashchange", loadFile, false);
 window.addEventListener("keydown", function(event){
   // ctrl and enter = render
-  if (event.ctrlKey && event.keyCode === 13) {
+  if((event.ctrlKey || event.metaKey) && event.which === 13) {
     event.preventDefault();
     render();
   }

--- a/sandbox/sandbox.js
+++ b/sandbox/sandbox.js
@@ -139,6 +139,13 @@ function loadFile() {
 }
 
 window.addEventListener("hashchange", loadFile, false);
+window.addEventListener("keydown", function(event){
+  // ctrl and enter = render
+  if (event.ctrlKey && event.keyCode === 13) {
+    event.preventDefault();
+    render();
+  }
+});
 
 function showError(msg) { alert(msg); }
 


### PR DESCRIPTION
I think that comes in quite handy because moving the mouse to hit the render button slows your experimentation down.
